### PR TITLE
default to pkg = "." when using grk_style_pkg

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,4 +25,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/R/style.R
+++ b/R/style.R
@@ -127,6 +127,6 @@ grk_style_dir <- function(path, ...) {
 #' @describeIn grk_style Style a package using the \pkg{grkstyle} code style
 #' @inheritParams styler::style_pkg
 #' @export
-grk_style_pkg <- function(pkg, ...) {
+grk_style_pkg <- function(pkg = ".", ...) {
   styler::style_pkg(pkg, ..., transformers = grk_style_transformer())
 }

--- a/man/grk_style.Rd
+++ b/man/grk_style.Rd
@@ -20,7 +20,7 @@ grk_style_file(path, ...)
 
 grk_style_dir(path, ...)
 
-grk_style_pkg(pkg, ...)
+grk_style_pkg(pkg = ".", ...)
 }
 \arguments{
 \item{...}{Arguments passed to underling \pkg{styler} functions (identified


### PR DESCRIPTION
I think most of the time users will run the styler when their wd is the package, so instead of always doing `grk_style_pkg(".")`, this function now defaults to `pkg = "."`