### PR TITLE
Use tabs by default

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,4 +25,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: grkstyle
 Title: A Tidy R Code Style
-Version: 0.0.3
+Version: 0.1.0
 Authors@R: 
     person(given = "Garrick",
            family = "Aden-Buie",
@@ -11,7 +11,7 @@ Description: A tidy code style building on the tidyverse code
     style guidelines but with a small changes for consistent line breaks
     and indentation. Enforces line breaks, if there are any initially
     between arguments in function calls and left-indents arguments in
-    function definitions.
+    function definitions. Defaults to tabs, not spaces.
 License: MIT + file LICENSE
 URL: https://github.com/gadenbuie/grkstyle
 BugReports: https://github.com/gadenbuie/grkstyle/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,3 @@
+# grkstyle 0.1.0
+
+* Tabs are now preferred by default over spaces (#7).

--- a/README.Rmd
+++ b/README.Rmd
@@ -49,6 +49,33 @@ options(styler.addins_style_transformer = "grkstyle::grk_style_transformer()")
 
 A few examples drawn from the [tidyverse style guide](https://style.tidyverse.org).
 
+### Tabs vs Spaces
+
+I've been staunchly committed to indentation by two spaces,
+but I've recently come to realize that indentation with tabs is objectively better.
+Primarily [it's about accessibility](https://alexandersandberg.com/articles/default-to-tabs-instead-of-spaces-for-an-accessible-first-environment/).
+Using tabs allows others to choose their preferred indentation levels,
+it accommodates more code authors in a wider variety of scenarios,
+and it's better for Braille code readers:
+
+> The main reason I would like to see this change is for refreshable braille displays that are used by blind programmers a lot. Each space wastes one braille cell and takes away valuable braille realestate. So if the default indentation of a project is 4 spaces per level, a 3rd level indentation wastes 12 braille cells before code starts.  
+> — [Comment](https://github.com/prettier/prettier/issues/7475#issuecomment-668544890) by [MarcoZehe](https://github.com/MarcoZehe)
+
+**unstyled**
+
+```{r echo = FALSE, results = "asis"}
+text_vec <- 'fruits <- c(\n  "apple",\n  "banana",\n  "mango"\n)'
+cat("\n``` r", text_vec, "```", sep = "\n")
+```
+
+**grkstyle**
+
+```{r, echo=FALSE, results="asis"}
+text_vec <- grkstyle::grk_style_text(text_vec)
+
+cat("\n``` r", paste(text_vec, collapse = "\n"), "```", sep = "\n")
+```
+
 ### Line Breaks Inside Function Calls
 
 **unstyled**

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 # grkstyle
 
 <!-- badges: start -->
-
 <!-- badges: end -->
 
 `grkstyle` is an extension package for
@@ -38,6 +37,45 @@ Or add the following to your `~/.Rprofile`
 A few examples drawn from the [tidyverse style
 guide](https://style.tidyverse.org).
 
+### Tabs vs Spaces
+
+I’ve been staunchly committed to indentation by two spaces, but I’ve
+recently come to realize that indentation with tabs is objectively
+better. Primarily [it’s about
+accessibility](https://alexandersandberg.com/articles/default-to-tabs-instead-of-spaces-for-an-accessible-first-environment/).
+Using tabs allows others to choose their preferred indentation levels,
+it accommodates more code authors in a wider variety of scenarios, and
+it’s better for Braille code readers:
+
+> The main reason I would like to see this change is for refreshable
+> braille displays that are used by blind programmers a lot. Each space
+> wastes one braille cell and takes away valuable braille realestate. So
+> if the default indentation of a project is 4 spaces per level, a 3rd
+> level indentation wastes 12 braille cells before code starts.  
+> —
+> [Comment](https://github.com/prettier/prettier/issues/7475#issuecomment-668544890)
+> by [MarcoZehe](https://github.com/MarcoZehe)
+
+**unstyled**
+
+``` r
+fruits <- c(
+  "apple",
+  "banana",
+  "mango"
+)
+```
+
+**grkstyle**
+
+``` r
+fruits <- c(
+    "apple",
+    "banana",
+    "mango"
+)
+```
+
 ### Line Breaks Inside Function Calls
 
 **unstyled**
@@ -51,13 +89,13 @@ do_something_very_complicated(something = "that", requires = many,
 
 ``` r
 do_something_very_complicated(
-  something = "that",
-  requires = many,
-  arguments = "some of which may be long"
+    something = "that",
+    requires = many,
+    arguments = "some of which may be long"
 ) 
 ```
 
-**styler::tidyverse\_style**
+**styler::tidyverse_style**
 
 ``` r
 do_something_very_complicated(
@@ -82,15 +120,15 @@ long_function_name <- function(a = "a long argument",
 
 ``` r
 long_function_name <- function(
-  a = "a long argument",
-  b = "another argument",
-  c = "another long argument"
+    a = "a long argument",
+    b = "another argument",
+    c = "another long argument"
 ) {
-  # As usual code is indented by two spaces.
+    # As usual code is indented by two spaces.
 } 
 ```
 
-**styler::tidyverse\_style**
+**styler::tidyverse_style**
 
 ``` r
 long_function_name <- function(a = "a long argument",

--- a/grkstyle.Rproj
+++ b/grkstyle.Rproj
@@ -5,7 +5,7 @@ SaveWorkspace: No
 AlwaysSaveHistory: Default
 
 EnableCodeIndexing: Yes
-UseSpacesForTab: Yes
+UseSpacesForTab: No
 NumSpacesForTab: 2
 Encoding: UTF-8
 

--- a/man/grk_style.Rd
+++ b/man/grk_style.Rd
@@ -12,7 +12,7 @@
 \usage{
 use_grk_style()
 
-grk_style_transformer(...)
+grk_style_transformer(..., use_tabs = getOption("grkstyle.use_tabs", TRUE))
 
 grk_style_text(text, ...)
 
@@ -26,6 +26,20 @@ grk_style_pkg(pkg = ".", ...)
 \item{...}{Arguments passed to underling \pkg{styler} functions (identified
 by removing the \code{grk_} prefix), except for \code{transofrmers}, which is set to
 the \code{grk_style_transformer()} internally.}
+
+\item{use_tabs}{Should a single tab be used for indentation? The new default
+in \pkg{grkstyle} is \code{TRUE}, meaning that tabs are used. I set the RStudio
+global option to show tabs as two spaces. Tabs are recommended because they
+are \href{https://alexandersandberg.com/articles/default-to-tabs-instead-of-spaces-for-an-accessible-first-environment/}{more accessible}.
+
+You can opt into indentation by two spaces by setting the
+\code{grkstyle.use_tabs} option:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# two spaces
+options(grkstyle.use_tabs = FALSE)
+# equivalent
+options(grkstyle.use_tabs = list(indent_by = 2, indent_character = " "))
+}\if{html}{\out{</div>}}}
 
 \item{text}{A character vector with text to style.}
 
@@ -62,8 +76,10 @@ function arguments in function definitions.
 code style as the default code style for \pkg{styler} (and its associated
 RStudio addins, like "Style active file" and "Style selection") by calling
 \code{grkstyle::use_grk_style()}. If you would rather set this option globally
-for all session, you can add the following to your \code{.Rprofile}:\preformatted{options(styler.addins_style_transformer = "grkstyle::grk_style_transformer()")
-}
+for all session, you can add the following to your \code{.Rprofile}:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{options(styler.addins_style_transformer = "grkstyle::grk_style_transformer()")
+}\if{html}{\out{</div>}}
 }
 
 \examples{

--- a/tests/testthat/_snaps/style.md
+++ b/tests/testthat/_snaps/style.md
@@ -1,0 +1,37 @@
+# tabs not spaces
+
+    Code
+      as_grk_styled_text(text_vec)
+    Output
+      fruits <- c(
+      	"apple",
+      	"banana",
+      	"mango"
+      )
+
+# line breaks
+
+    Code
+      as_grk_styled_text(text_line_breaks)
+    Output
+      
+      do_something_very_complicated(
+      	something = "that",
+      	requires = many,
+      	arguments = "some of which may be long"
+      )
+
+# function args
+
+    Code
+      as_grk_styled_text(text_fn_args)
+    Output
+      
+      long_function_name <- function(
+      	a = "a long argument",
+      	b = "another argument",
+      	c = "another long argument"
+      ) {
+      	# As usual code is indented by two spaces.
+      }
+

--- a/tests/testthat/test-style.R
+++ b/tests/testthat/test-style.R
@@ -1,13 +1,43 @@
 test_that("xaringan comments work", {
-  code <- 'base <- c(
-  "grep",
-  "grepl",
-  "sub", #<<
-  "gsub", #<<
-  "regexpr",
-  "gregexpr",
-  "regexec"
+	code <- 'base <- c(
+\t"grep",
+\t"grepl",
+\t"sub", #<<
+\t"gsub", #<<
+\t"regexpr",
+\t"gregexpr",
+\t"regexec"
 )'
-  code_styled <- grk_style_text(code)
-  expect_equal(paste(code_styled, collapse = "\n"), code)
+	code_styled <- grk_style_text(code)
+	expect_equal(paste(code_styled, collapse = "\n"), code)
+})
+
+as_grk_styled_text <- function(text) {
+	grk <- unclass(grkstyle::grk_style_text(text))
+	grk <- paste(grk, collapse = "\n")
+	cat(grk)
+}
+
+test_that("tabs not spaces", {
+	text_vec <- 'fruits <- c(\n  "apple",\n  "banana",\n  "mango"\n)'
+	expect_snapshot(as_grk_styled_text(text_vec))
+})
+
+test_that("line breaks", {
+	text_line_breaks <- '
+do_something_very_complicated(something = "that", requires = many,
+                              arguments = "some of which may be long")
+'
+	expect_snapshot(as_grk_styled_text(text_line_breaks))
+})
+
+test_that("function args", {
+	text_fn_args <- '
+long_function_name <- function(a = "a long argument",
+                               b = "another argument",
+                               c = "another long argument") {
+  # As usual code is indented by two spaces.
+}
+'
+	expect_snapshot(as_grk_styled_text(text_fn_args))
 })


### PR DESCRIPTION
Makes tabs the new default.

## Why?

From the readme:

> I’ve been staunchly committed to indentation by two spaces, but I’ve recently come to realize that indentation with tabs is objectively better. Primarily [it’s about accessibility](https://alexandersandberg.com/articles/default-to-tabs-instead-of-spaces-for-an-accessible-first-environment/). Using tabs allows others to choose their preferred indentation levels, it accommodates more code authors in a wider variety of scenarios, and it’s better for Braille code readers:
> 
> > The main reason I would like to see this change is for refreshable braille displays that are used by blind programmers a lot. Each space wastes one braille cell and takes away valuable braille realestate. So if the default indentation of a project is 4 spaces per level, a 3rd level indentation wastes 12 braille cells before code starts.  
> > — [Comment](https://github.com/prettier/prettier/issues/7475#issuecomment-668544890) by [MarcoZehe](https://github.com/MarcoZehe)
> 
> **unstyled**
> 
> ``` r
> fruits <- c(
>   "apple",
>   "banana",
>   "mango"
> )
> ```
> 
> **grkstyle**
> 
> ``` r
> fruits <- c(
>     "apple",
>     "banana",
>     "mango"
> )
> ```

## Technical Notes

You can opt back into the spaces version by setting

```r
# two spaces
options(grkstyle.use_tabs = FALSE)
```

Or you can make your own choices about indentation characters

```r
# equivalently, but more precise
options(grkstyle.use_tabs = list(indent_by = 2, indent_character = " "))
```